### PR TITLE
docs: Update README with library status table

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@ This monorepo contains a collection of libraries which implement/wrap existing U
 
 ## Available Libraries
 
-### NgxGovUKFrontend
-
-A comprehensive implementation of the [GOV.UK Design System](https://design-system.service.gov.uk/) for Angular applications.
-
-- [Documentation](https://jonnyheavey.github.io/ngx-uk-frontend)
-- [README](libs/ngx-govuk-frontend/README.md)
+| Library                  | Description                                                  | Status             | NPM Link                                                       |
+| ------------------------ | ------------------------------------------------------------ | ------------------ | -------------------------------------------------------------- |
+| `ngx-govuk-frontend`     | Angular components for the GOV.UK Design System              | Published          | [ngx-govuk-frontend](https://www.npmjs.com/package/ngx-govuk-frontend) |
+| `ngx-govscot-frontend`   | Angular components for the Scottish Government Design System | Under Construction | -                                                              |
+| `ngx-nhsuk-frontend`     | Angular components for the NHS.UK Design System              | Under Construction | -                                                              |
 
 ## Development
 


### PR DESCRIPTION
Adds a table to the main README.md to outline each publishable library, its description, status (published/under construction), and a link to its NPM package if published.